### PR TITLE
Setting up ldap logging in fluentd. 

### DIFF
--- a/palo-alto/user-id_ldap/configurations/file-fluent.conf
+++ b/palo-alto/user-id_ldap/configurations/file-fluent.conf
@@ -1,0 +1,18 @@
+<source>
+  @type tail
+  path /fluentd/log/files/ldap.log
+  pos_file /var/log/td-agent/ldap.pos
+  tag ldap-access.log
+  <parse>
+    @type multiline
+    format_firstline /\w+ conn=\d+ fd=\d+ ACCEPT from IP=(?<source>\d+.\d+.\d+.\d+).+/
+    format1 /\w+ conn=\d+ fd=\d+ ACCEPT from IP=(?<source>\d+.\d+.\d+.\d+).+/
+    format2 /\w+ conn=\d+ op=\d+ BIND dn="cn=(?<user>\w+),cn=(?<group>\w+),dc=(?<domain>\w+),dc=(?<com>\w+)".+/
+  </parse>
+</source>
+
+<match ldap-access.log>
+   @type file
+   path /output/ldap-access.log
+</match>
+


### PR DESCRIPTION
Setting up ldap logging in fluentd. These logs will be sent to the palo alto user-id api.