### PR TITLE
Added python3 intepreter for webserver host to docker module to work correctly.

### DIFF
--- a/palo-alto/ansible_scripts/inventory.ini
+++ b/palo-alto/ansible_scripts/inventory.ini
@@ -3,3 +3,6 @@
 
 [webserver]
 10.80.1.42
+
+[webserver:vars]
+ansible_python_interpreter=/usr/bin/python3

--- a/palo-alto/ansible_scripts/playbook.yaml
+++ b/palo-alto/ansible_scripts/playbook.yaml
@@ -23,9 +23,11 @@
         - "389:389"
         - "636:636"
       env:
-        - LDAP_ORGANISATION:"AUTOZONE" 
-        - LDAP_DOMAIN:"AUTOZONE.com" 
-        - LDAP_ADMIN_PASSWORD:"test123" 
+        "LDAP_ORGANISATION": "AUTOZONE" 
+        "LDAP_DOMAIN": "AUTOZONE.com"
+        "LDAP_ADMIN_PASSWORD": "test123"
+      vars:
+        ansible_python_interpreter: /bin/python3
   - name: Stopping httpd
     ansible.builtin.service:
       name: httpd


### PR DESCRIPTION
Added python3 intepreter for webserver host to docker module to work correctly.