### PR TITLE
Python instead of python3 in fluent.conf file

### DIFF
--- a/palo-alto/user-id_ldap/configurations/fluent.conf
+++ b/palo-alto/user-id_ldap/configurations/fluent.conf
@@ -29,7 +29,7 @@
 
 <match ldap-access.log>
   @type exec
-  command python3 /output/test.py
+  command python /output/test.py
   buffer_path /output
   format tsv
   keys timestamp,ip,username,group


### PR DESCRIPTION
Python instead of python3 in fluent.conf file